### PR TITLE
0.6.2

### DIFF
--- a/Examples/Classic/blob/Package.swift
+++ b/Examples/Classic/blob/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.1"),
+        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Examples/Classic/blob/Package.swift
+++ b/Examples/Classic/blob/Package.swift
@@ -1,23 +1,26 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "blob",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     products: [
         .executable(name: "functions", targets: ["blob"]),
      ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.0.1"),
+        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "blob",
-            dependencies: ["AzureFunctions"])
+            dependencies: [.product(name: "AzureFunctions", package: "azure-functions-swift")])
     ]
 )

--- a/Examples/Classic/http/Package.swift
+++ b/Examples/Classic/http/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.1"),
+        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Examples/Classic/http/Package.swift
+++ b/Examples/Classic/http/Package.swift
@@ -1,23 +1,26 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "http",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     products: [
         .executable(name: "functions", targets: ["http"]),
      ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-         .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.0.1"),
+        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "http",
-            dependencies: ["AzureFunctions"])
+            dependencies: [.product(name: "AzureFunctions", package: "azure-functions-swift")])
     ]
 )

--- a/Examples/Classic/queue/Package.swift
+++ b/Examples/Classic/queue/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.1"),
+        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Examples/Classic/queue/Package.swift
+++ b/Examples/Classic/queue/Package.swift
@@ -1,23 +1,26 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "queue",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     products: [
         .executable(name: "functions", targets: ["queue"]),
      ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-         .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.0.1"),
+        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "queue",
-            dependencies: ["AzureFunctions"])
+            dependencies: [.product(name: "AzureFunctions", package: "azure-functions-swift")])
     ]
 )

--- a/Examples/Classic/servicebus/Package.swift
+++ b/Examples/Classic/servicebus/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.1"),
+        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Examples/Classic/servicebus/Package.swift
+++ b/Examples/Classic/servicebus/Package.swift
@@ -1,23 +1,26 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "servicebus",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     products: [
         .executable(name: "functions", targets: ["servicebus"]),
      ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-         .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.0.1"),
+        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "servicebus",
-            dependencies: ["AzureFunctions"])
+            dependencies: [.product(name: "AzureFunctions", package: "azure-functions-swift")])
     ]
 )

--- a/Examples/Classic/timer/Package.swift
+++ b/Examples/Classic/timer/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.1"),
+        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Examples/Classic/timer/Package.swift
+++ b/Examples/Classic/timer/Package.swift
@@ -1,23 +1,26 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "timer",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     products: [
         .executable(name: "functions", targets: ["timer"]),
      ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-         .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.0.1"),
+        .package(url: "https://github.com/SalehAlbuga/azure-functions-swift", from: "0.6.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "timer",
-            dependencies: ["AzureFunctions"])
+            dependencies: [.product(name: "AzureFunctions", package: "azure-functions-swift")])
     ]
 )

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "e2f5be30e4c8f531c9c1e8765aa7b71c0a45d7a0",
-          "version": "0.9.2"
+          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
+          "version": "1.0.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "0e9a78d6584e3812cd9c09494d5c7b483e8f533c",
-          "version": "0.13.1"
+          "revision": "94197b3adbbf926348ad8765476a158aa4e54f8a",
+          "version": "0.14.0"
         }
       },
       {

--- a/Sources/AzureFunctions/CodeGen.swift
+++ b/Sources/AzureFunctions/CodeGen.swift
@@ -54,7 +54,7 @@ internal struct CodeGen {
         } else if let storage = registry.AzureWebJobsStorage {
             localSetRes = try environment.renderTemplate(string: settingsJsontemplate, context: ["envVars": "\"AzureWebJobsStorage\": \"\(storage)\""])
         } else {
-            localSetRes = try environment.renderTemplate(string: settingsJsontemplate, context: nil)
+            localSetRes = try environment.renderTemplate(string: settingsJsontemplate, context: [:])
         }
        
         let localSetFile = try rootFolder.createFile(named: "local.settings.json")


### PR DESCRIPTION
* An option to set exec path in the exported host/WorkerConf files to the default value "/home/site/wwwroot/.."
* Publish command was added to CLI tools to publish & run Swift functions in a consumption plan 
* Fixing an error caused by breaking change in a dependency
